### PR TITLE
chore: upgrade to nixos 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -121,22 +121,10 @@
     },
     "crane": {
       "inputs": {
-        "flake-compat": [
-          "lanzaboote",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "lanzaboote",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "lanzaboote",
-          "nixpkgs"
-        ],
-        "rust-overlay": [
-          "lanzaboote",
-          "rust-overlay"
-        ]
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
         "lastModified": 1681177078,
@@ -180,16 +168,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1725377834,
-        "narHash": "sha256-tqoAO8oT6zEUDXte98cvA1saU9+1dLJQe3pMKLXv8ps=",
+        "lastModified": 1746728054,
+        "narHash": "sha256-eDoSOhxGEm2PykZFa/x9QG5eTH0MJdiJ9aR00VAofXE=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "e55f9a8678adc02024a4877c2a403e3f6daf24fe",
+        "rev": "ff442f5d1425feb86344c028298548024f21256d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "v1.7.0",
+        "ref": "v1.12.0",
         "repo": "disko",
         "type": "github"
       }
@@ -213,6 +201,22 @@
     "flake-compat": {
       "flake": false,
       "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1673956053,
         "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
@@ -226,7 +230,7 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -242,7 +246,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1733328505,
@@ -278,16 +282,37 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -301,11 +326,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -316,10 +341,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": [
-          "stylix",
-          "systems"
-        ]
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -337,7 +359,25 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -353,9 +393,9 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_6": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -482,16 +522,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1732369855,
-        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
+        "lastModified": 1744584021,
+        "narHash": "sha256-0RJ4mJzf+klKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
+        "rev": "52c517c8f6c199a1d6f5118fae500ef69ea845ae",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "47.2",
+        "ref": "48.1",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -582,16 +622,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "lastModified": 1747556831,
+        "narHash": "sha256-Qb84nbYFFk0DzFeqVoHltS2RodAYY5/HZQKE8WnBDsc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
+        "rev": "d0bbd221482c2713cccb80220f3c9d16a6e20a33",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -614,28 +654,27 @@
     "lanzaboote": {
       "inputs": {
         "crane": "crane",
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "flake-parts": [
           "flake-parts"
         ],
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1682802423,
-        "narHash": "sha256-Fb5TeRTdvUlo/5Yi2d+FC8a6KoRLk2h1VE0/peMhWPs=",
+        "lastModified": 1737639419,
+        "narHash": "sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "64b903ca87d18cef2752c19c098af275c6e51d63",
+        "rev": "a65905a09e2c43ff63be8c0e86a93712361f871e",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "v0.3.0",
+        "ref": "v0.4.2",
         "repo": "lanzaboote",
         "type": "github"
       }
@@ -663,7 +702,7 @@
     "nix-topology": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -685,16 +724,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747862697,
-        "narHash": "sha256-U4HaNZ1W26cbOVm0Eb5OdGSnfQVWQKbLSPrSSa78KC0=",
-        "owner": "nixos",
+        "lastModified": 1747958103,
+        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2baa12ff69913392faf0ace833bc54bba297ea95",
+        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.11",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -715,18 +754,18 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1748026106,
-        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
+        "lastModified": 1748162331,
+        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
+        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -735,22 +774,21 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-ovmf": [
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1712439808,
-        "narHash": "sha256-QoONoZPBpNTw5cia05QSvDlaxXo3moKAJQOw7c5hMXA=",
-        "rev": "9f1cdca730d92461075709e867c1e9ad93d58a8d",
-        "revCount": 284,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/AshleyYakeley/NixVirt/0.5.0/018eb55e-7beb-75c5-919f-5b5b26136e06/source.tar.gz"
+        "lastModified": 1748140003,
+        "narHash": "sha256-DNBZmuk1YRM2PmwbHzVdXumRjCUzQkMarg4iI/37rOQ=",
+        "owner": "AshleyYakeley",
+        "repo": "NixVirt",
+        "rev": "5dfe108fd859b122f9a96981cb6bc12297653d6c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/AshleyYakeley/NixVirt/0.5.0.tar.gz"
+        "owner": "AshleyYakeley",
+        "ref": "v0.6.0",
+        "repo": "NixVirt",
+        "type": "github"
       }
     },
     "nur": {
@@ -779,9 +817,35 @@
         "type": "github"
       }
     },
+    "nur_2": {
+      "inputs": {
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1748202304,
+        "narHash": "sha256-z5aLC0QdFhYKeCmXNoSkOIc7/xJHrUltY0p0MzO1bO0=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "621b7cd2462057ad0cf365b28e99ea95a3916bc4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "nix-topology",
@@ -812,10 +876,7 @@
           "lanzaboote",
           "flake-compat"
         ],
-        "flake-utils": [
-          "lanzaboote",
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "lanzaboote",
@@ -850,24 +911,42 @@
         "lanzaboote": "lanzaboote",
         "nix-index-database": "nix-index-database",
         "nix-topology": "nix-topology",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs": "nixpkgs_2",
         "nixvirt": "nixvirt",
         "nur": "nur",
         "sops-nix": "sops-nix",
         "spicetify": "spicetify",
         "stylix": "stylix",
-        "treefmt-nix": "treefmt-nix",
+        "treefmt-nix": "treefmt-nix_2",
         "vscode-extensions": "vscode-extensions",
         "vscode-server": "vscode-server"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
+        "nixpkgs": [
           "lanzaboote",
-          "flake-utils"
-        ],
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1748140821,
+        "narHash": "sha256-GZcjWLQtDifSYMd1ueLDmuVTcQQdD5mONIBTqABooOk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "476b2ba7dc99ddbf70b1f45357dbbdbdbdfb4422",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
@@ -912,19 +991,18 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_3"
+        "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1743595372,
-        "narHash": "sha256-e3x1mhpPpYgyyin9j/VbrBpOT5PFpEfx2hkxVZuJZhg=",
+        "lastModified": 1748147548,
+        "narHash": "sha256-9IaAQkgyF4PFtVyui8vF6oJah0iVcO9DaOefjdTMthE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "543f12dd14c62ddee79ab79fbfd8726f312b89ff",
+        "rev": "f0595e3b59260457042450749eaec00a5a47db35",
         "type": "github"
       },
       "original": {
         "owner": "Gerg-L",
-        "ref": "24.11",
         "repo": "spicetify-nix",
         "type": "github"
       }
@@ -936,8 +1014,8 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_3",
+        "flake-compat": "flake-compat_4",
+        "flake-parts": "flake-parts_2",
         "git-hooks": "git-hooks",
         "gnome-shell": "gnome-shell",
         "home-manager": [
@@ -946,22 +1024,25 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_4",
+        "nur": "nur_2",
+        "systems": "systems_6",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
-        "tinted-tmux": "tinted-tmux"
+        "tinted-schemes": "tinted-schemes",
+        "tinted-tmux": "tinted-tmux",
+        "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747771231,
-        "narHash": "sha256-DYdmj22ZvkN5x9/VtdV5Wnze+UaPuboYraCPnOWn6u4=",
-        "owner": "danth",
+        "lastModified": 1748029503,
+        "narHash": "sha256-qHewVAhQ2kaZLHcO9lDzMeAGDFmbDd36kls7bi7HgMQ=",
+        "owner": "nix-community",
         "repo": "stylix",
-        "rev": "66f554e4e32d804bcf2c007a7b7efef04a3773b0",
+        "rev": "df93f602dd8c84e7bd067654cc2f6422d5868496",
         "type": "github"
       },
       "original": {
-        "owner": "danth",
-        "ref": "release-24.11",
+        "owner": "nix-community",
+        "ref": "release-25.05",
         "repo": "stylix",
         "type": "github"
       }
@@ -1056,6 +1137,36 @@
         "type": "github"
       }
     },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_8": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "tinted-foot": {
       "flake": false,
       "locked": {
@@ -1076,17 +1187,32 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716423189,
-        "narHash": "sha256-2xF3sH7UIwegn+2gKzMpFi3pk5DlIlM18+vj17Uf82U=",
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1748180480,
+        "narHash": "sha256-7n0XiZiEHl2zRhDwZd/g+p38xwEoWtT0/aESwTMXWG4=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "87d652edd26f5c0c99deda5ae13dfb8ece2ffe31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
         "type": "github"
       }
     },
@@ -1106,7 +1232,45 @@
         "type": "github"
       }
     },
+    "tinted-zed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725758778,
+        "narHash": "sha256-8P1b6mJWyYcu36WRlSVbuj575QWIFZALZMTg5ID/sM4=",
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "rev": "122c9e5c0e6f27211361a04fae92df97940eccf9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "stylix",
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733222881,
+        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -1128,7 +1292,7 @@
     },
     "vscode-extensions": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1149,7 +1313,7 @@
     },
     "vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -31,7 +30,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    home-manager.url = "github:nix-community/home-manager/release-24.11";
+    home-manager.url = "github:nix-community/home-manager/release-25.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     nur = {
@@ -49,19 +48,19 @@
     };
 
     stylix = {
-      url = "github:/danth/stylix/release-24.11";
+      url = "github:/nix-community/stylix/release-25.05";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.home-manager.follows = "home-manager";
     };
 
     spicetify = {
-      url = "github:Gerg-L/spicetify-nix/24.11";
+      url = "github:Gerg-L/spicetify-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     hardware.url = "github:nixos/nixos-hardware";
     disko = {
-      url = "github:nix-community/disko/v1.7.0";
+      url = "github:nix-community/disko/v1.12.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -80,9 +79,8 @@
     };
 
     nixvirt = {
-      url = "https://flakehub.com/f/AshleyYakeley/NixVirt/0.5.0.tar.gz";
+      url = "github:AshleyYakeley/NixVirt/v0.6.0";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-ovmf.follows = "nixpkgs";
     };
 
     arion = {
@@ -92,7 +90,7 @@
     };
 
     lanzaboote = {
-      url = "github:nix-community/lanzaboote/v0.3.0";
+      url = "github:nix-community/lanzaboote/v0.4.2";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-parts.follows = "flake-parts";
     };

--- a/home/akos/features/desktop/common/yubilock/src/server.rs
+++ b/home/akos/features/desktop/common/yubilock/src/server.rs
@@ -3,13 +3,13 @@ use std::{collections::HashSet, io::Result, path::Path, str::FromStr, sync::Arc}
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{
-        unix::{OwnedReadHalf, OwnedWriteHalf},
         UnixListener,
+        unix::{OwnedReadHalf, OwnedWriteHalf},
     },
     select,
     sync::{
-        mpsc::{self, UnboundedReceiver, UnboundedSender},
         Mutex,
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
     },
     time::Instant,
 };

--- a/hosts/common/global/stylix.nix
+++ b/hosts/common/global/stylix.nix
@@ -16,8 +16,8 @@
       };
       sansSerif = config.stylix.fonts.serif;
       monospace = {
-        package = pkgs.nerdfonts.override { fonts = [ "Recursive" ]; };
-        name = "RecMono Linear Nerd Font";
+        package = pkgs.nerd-fonts.recursive-mono;
+        name = "RecMonoLinear Nerd Font";
       };
       emoji = {
         package = pkgs.noto-fonts-emoji;

--- a/hosts/gaia/secrets.yaml
+++ b/hosts/gaia/secrets.yaml
@@ -1,4 +1,4 @@
-cloudflare-dyndns-token: ENC[AES256_GCM,data:c+F//2TP1Q7IVO15TOYnF7N6ZHL+dtPPNHP4I/wq6NZ+vMfE4qVgsT0Yriqa8VOrLPV+1kD9dJP01FpmuA==,iv:cMiBRs/WHi8IiIxaFk01ZxxAVoNvm7+s0QmxjToXFNY=,tag:xEeS3FIS0PW+Cx1+tYVISg==,type:str]
+cloudflare-dyndns-token: ENC[AES256_GCM,data:uWFgv/YAVRREc/q44KuyTByhP11rZi4QH0nHDlik+0TuxWx67XiccA==,iv:hSUgUUBPYCHcrZg25VfuuESvzuxOWL+FlOovcCqibCk=,tag:2mSd4ypUzI/M0z+Po1+jiw==,type:str]
 hass-token: ENC[AES256_GCM,data:SIy/+LWUnRNPA60D9f50cLrZrjzFdu/9Kmn+HaMkypvGAv6PHvAqVcNPIt4RDSvcwydLqsrfdnAAy2xypj2Kzx64BZZU15DtjagBDF3Mbzis92Au+NXx4A9LrV8tLdOZ1LN+sJ/A4iEBWxbvclu3UA8m92RDLQEzoOLrt6uJk05PhepuhiJkumywaT6KxDYarhOr0JfLuNAD9inUszDL3xgbjmD6ZOJDIeI6k3nPy56FkM2dkxRFcxBE90GaVtdHS72r3PbYWPd5QSw=,iv:MVvMDZd6mROba0Np6fWsf9LWwtrKVhCpZkQX8s6KaXs=,tag:/Wpc2twBJe5Fv60NvpASgQ==,type:str]
 restic-hass-password: ENC[AES256_GCM,data:009rulyVCN5PO5k83v+3THzv45RhnhCz,iv:hvhvKZGcPr3lwGaGwiZ388JVXqcdcHcOrOg89Ksv+uE=,tag:0MYKsswG39slJ6ghhGN15A==,type:str]
 restic-gaia-persist-password: ENC[AES256_GCM,data:9+4PIyqK1htV3TCJPZN10g==,iv:IUX1I45IXoqAcqVcTZlXHfjK23BxSWY8jrZ5HXlQcfg=,tag:oTmzLTFAzvSTjDd6UEN4Kg==,type:str]
@@ -12,10 +12,6 @@ mosquitto-cafile: ENC[AES256_GCM,data:wj1y+R5cu8rAKUQPFtUwBNyB6U/MOsRxNMafV5F7+L
 mosquitto-certfile: ENC[AES256_GCM,data:HJfKr579Smpe1pPddzq7BkYlunv2zbjWRITfbvnJQ5ITqQFNG/kvLCKkJqYDZio+S+s0UpWRikPJYsD8ys9W0lop/44la/4a9q/AQvJ4Xj3va4tAxuIL7cTPbCazBj+gFenl7O0Flh9NHsJ3Dj0vV3c7urj6hwmlUOVhmyp3VWdULsXyc5zDh5DnMuW9drIMQHxEPrWYjNs2dqLPFVTVm2RV4UEgJtNTzNBguC7sCS2P9M8jbOAdlKN+H56VKAVSI6uxn/4eRtZznkig1PycFUBTdMEgmieyFer/fsvqvIbOe9kZ1e+UbwWh+BdG1L+Ieg4e+uNJpBYXjDSbUSzI5aSbjqOiBkSfWgMcAXtLQmkw/9jfTAXQkwa1r/UVJU234mO2Vl4/dnfMEe0pVPP7AzAv/DKnoDHjbOhHrjwuYoF4UxbCv6teMnZhusmoUwcpg0ni8GMs1OSDSTrgVTthdQO3z6EXdmeTbIDbJMhfZ43TGgGBga8cYChsdJ7f3IHtnqNWaiw8JWEWSHM+zQEbmiiAZ7bzQm3u5QxSMmUbDDdGjyAwLF5g+TQxyomrG3+Wgb5F95y+wF3B4vigRXlyzn4IzjJ4MfpoBVyT04DZ7CE1nkkOR4JdZNR0V2dKldxpuIfpmE7GzN/bLHtXV+O8dQsdYht6JIMSooTfob8ecKRih3VfiFYKbZ6rneTgm3KJYKt7CzwifJW9WvDkmLlmwJN1OAdQHxLlZ8lkuDSoVyCACl246/2dbwXgxTwWNN/MzUHng/XVC7ekD4zVF5S96+bIQeAAKTG4Q6pKNzDjJKVZGCx/1kpWNQUiqRaJzrckwNZAChGxLx0WYuVTQcncmJ0uID4ZhGM5ixAsIdBuP+RJ2Lx2EjowS0Fk/DPoaWrrwuH5BSMZ1jK+sZCGs5W+wughgZq1Ud63kfoPXNKUrAZs9lHpFqZv14BIG3uvPswQgC97htikI+zvuz7UcqTw52vtb/k0StwGl62Srmm6AQKTAStCK3v5K70RsBnKkbZ9tmXM8A/RIuJx0zLqkw0N63a11Mkw5Um+q5mo8sjo3geIicjpCfaLaW64M+DvSNR2b1tCU5q+5F5FtdrBoR1jZgBGhvKEXrBBkEf+zr+QwqeQC/sug0EmXXSAciZVkIBifXH7rOtSARFOOAsFuholWwfdPS/PVceayWecreIh4Xk8zVEQ3w8tcjrMH/XM6AgmMoGxgpme/gyps9ge2yvYB32da0ID4AXog6mv6EsH1fxR9blYP0ivAxAdIBEvsaHPzvX0+XqiQWEkkaVGcxbz5DOQD6nhUOdVbzQgZwaYZmU4uD7sGbisejW3R/Q+ncwJShHwiIwQ555L0kxr4+xtcklvGYwTyXbpntJC8a015YsG0mr9dwIb5UGhlvs5DF1gBk463ZZBiufHACzV1RaLWqy1fXa04nailtKeyKvdVem3Sj4EfcS5kfbjpfH7wfR7hW+qmApBfKG314Wlf6JQtgeGdxUnPR20BXta02CPxj0F810s+rtxWznwv0C3tcC7AzRAAAqSWVbnBNA3iDBzp9Mc2+GcrFZ7u2eEzuBDi7fm5DyVoRwWoST1RKZ9bIR9CZzZJMjtjFWs/NVnJnDk45OYJCg=,iv:w2ujpGBZyMkK3wLIi22D9NrHaPXCxdghozWvnKUxIfM=,tag:8TUEBbU3Alo4n+on+5bPeQ==,type:str]
 mosquitto-keyfile: ENC[AES256_GCM,data:ZPURIzMZwKgH/YqjWBUsSOLx9rn4535XlfqDRAQEpMXLfglHYNMFtRba9lkABtOwCLPBLEF3UldMXRKlYIWF6/qSjitaNAPSxsP+KgXusJD6mzkU0jBH0f0HLmdq5yOMADtZmostaU5p0BOvm0x2itvahRUVAB/gVvHhfljx9aL3l/uDWbGs2hvX4jpwNcyh1gf1SVtAmnucllFNTPlVOqFi1X4HpkiMQSVk7qqi+Ealn1kgK4ayeTpqlRAhz6mi8l9zc5qC1+YtdpXlQnw8Of3M5Vihnx7Nw6odMFPRxfVo/ocOmr3xeeTzJbt1fePIthNy94FuDZbSuCMycTnOMEhtB2JfDPEInUPAwekbYgZarRiiJybfiRzJDuot50a5HtGNDaqCbGVwWlGWDNuoZpC01OaoA1/jgi7jwNn2CLoa2PZCuq8vt5PvU2zM4pmMQyj6/ZZJXDz2iwQZ+YzdS3rMmRlRryFil2UBJ41oGWtBKQ+fn5yskv075vlz4h/583QJ4tfxTrOvSLA1DPlTJYA8e4g9aUfKLs87zn/fOXUtxSKkaXVct5AMOWqsTN94BDG1NOCC7aaSGF0ZBnNmSTrbprV4xU8/Telorwp3z5hCC2qnGgb3iphx2gfT6AyWqAkVV/OVSUnjjMQ7DmEgtMU0Z4VB/nRdMNZSHSa/yOIaP5W19YJcbEl5pmWv+eqzsqC3MGj1t22d4mCazTh1/XkfcLXyda8zUDXMxC8gQpAMhqNKWTX191rz2jgYIp3TQN9bBZDoAYDdKHL1OgUlOgfYWOhYRtZ7P2Wapu2HD24uYsRhV4mah0MSoW54FpzcOUwLkcMoTrtMpxXV1Bv+O8vXAL5tGZZS84V6mmXMfcDoWhIJyz1fAx+54iUak8LBf+3uEv8XcVjqnreRKcpuzyZi0k6Tmcf1R2uEWt/vxneYLBu4iLSp1vf1lrgy6TZtNKOV++FpbMZr4HsJjumhyGO6qQ/k57/ghLMnBVtjKjH9LoeANwTZc94xlEJUUvOL/5+qjw1LkqyhNBp0MnCikZJp/Q1Oryyo2O8criACTJdYWoIRE5KbJVDP+7Sir2NfpUtiG2ExC0tjQTs4Bv82GXku4Z59ITgLQSzBVQw8+XlYga+eogEbd9Xo/B9lAEFZ84D/4EybV1ST66R/u9TDze80dQ77ql+7UiZtp/4aRgfd9Ovr6n+I+IS+MbZ/aIhFpvmRbl8ByAgX/7TBCadYxzuVdnTSHTQTv93Otu9J77geNhq9wxfm10kCSUKOiy9E5K+hJy4ZpsQVxNJPtJbrXbK8UCNpqJq9pCzivRSPlvYfDJlePMnr6BZCPTm5MjxqbvEhJGXy1N9YEYgZW39nNd463zA8P9CYvwNgp3NNoJVUKzRm6c2IgGvSyXiOj6vTcMOdd5sOBP2FfQbIzyZuy0ncevh9R7tYQWnhgrZxH8Wm+wXRvUQpthkIPYUwo9e4Sm2crmZVhYCxnQpSFOyVhjvSDRYLSyRbYf7u/GCD+Mtui2yjwWEltIOg3NuWml3zfCuP9ooFt2oWG95em/7kNS/DQM1dAx2tP1R/8m2LhBadbku84KXOJ3NwRWf4LhDWNDG6weJk/KbYu5v5JSetkNGDHtA5KlUidAZcOMwgKqWdefPVziKYbYuI+7KKq6bs5zZKmBTeANh5UyHdcm0Jw9g4cjFF1DLOHUkh8nSb8OVTcXW+Xh34BOJN/vOw/2cK1zafFjj3zSvErR4IssJVO67/71U1EqHWG3v6EqBML24gpuvJdU/tbsYFM+OnQLrSTywEkqte7bfPfrOqL9wTZ7F6yxQ/quSgyAe9Y5kCNVqw7Su2ZknZwrp2VFa2J3kuxDQtbDP4AELnhdovmGmwik7inIUxlWcbJg9q9gVdB4U8n2ZB63A82pkRZfWFlj/DGB276o7/lOPaDaZzj/GHMaex+MrmESN0ej0YVOOaCTMvAUOgunYGHyfJEd6g/bYw8sef2XWlaKB0181iATeFF7U9Gxrfn2Ix2mfaikF059wTxIB4ou5ttT8U0e1p5vY8v9646UMorSzxUytBMQLmGuYbP7TKmEaajeL0zAN6gxTCr534BRbtvSdxaNOiMZAtl0uQBmUbACFrD1S5b3xH9twXDyopoirpwAV8zKmCF5zgepZNH3JPt7KIUyWUP2IOadu6pIhcOctxzzvLmA35t+8jaqyTWjR7PfngAKFcE40oBKp7T3nWba+gfBy/wP8sOVD+C0Ej6nGqwkfpwtfE6QKowOZrSRnt,iv:PdrUM5T1zF4RbsAY6pCEDchFOSv3LdiH8x/4st/QWMY=,tag:l4LXbOEpj25rGfR/GV1vig==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age1gqdrkenwc3dwk384285gtz0zzgfl2c55xklx2hvhr8c6h4duggyqwmy2w7
           enc: |
@@ -26,8 +22,8 @@ sops:
             REdJdmhmU3NWRFRCaWNwb1lPWjcxT28KsCRtl3ZJHHhHGX8XEYC1dPWbwTcI/cy1
             iDpWPl3ljCQHSMaKtfKYh8EHvdOslvFXxoLyISRPzsrgJiNL+uroPg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-05-07T13:31:00Z"
-    mac: ENC[AES256_GCM,data:qffcx/guEQOTcgX7XUoN0jaLMTbyohi/kCXwcIMWeaqJfZY/Gg8oYWpSkzE6G95zvrqjNBYg64JJZ8t1CqNP2cEDucpHuyfG61MX94dhBjeYIeLoGjf9I9G2PuA49r5DZsU+N06mHmg/91gIjlcnvv/cLYAugU5hIDtKX70+2Rc=,iv:9yi1U8tal627sv+XwkfL59cbduSuz163WLTxG+7vVtE=,tag:v2Subt1eN7ckL851bjHKPQ==,type:str]
+    lastmodified: "2025-05-25T20:00:35Z"
+    mac: ENC[AES256_GCM,data:a/1/E5fIyI6CiFEU+QOfrh5dHIfyjcIMXIQph7rOzYQwRJ3G0JAdC+qMrUXB4al846uNE6pF8NslFKxOvUjPrLh26a5NfGbAxTN6R2u9Lo56oSISjfa49UeoxVNHR4dZioI8ALIX94CCu6yym1R0fz3AiBdQVxQA59zgORSf3wc=,iv:KShT7KQ4Uddok7VkDfnq7+lADj1Mt4EJALjbdN3JV+c=,tag:kF8kgYm+NnmDuLCjr10ufw==,type:str]
     pgp:
         - created_at: "2024-08-14T14:52:59Z"
           enc: |-
@@ -61,4 +57,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: DC6C238558CF0FC39400BA2EE2256EAE7390AF2C
     unencrypted_suffix: _unencrypted
-    version: 3.9.4
+    version: 3.10.2

--- a/hosts/hyperion/containers/torrent/qbt-manager/src/main.rs
+++ b/hosts/hyperion/containers/torrent/qbt-manager/src/main.rs
@@ -1,9 +1,9 @@
 use qbit_rs::{
+    Qbit,
     model::{
         Credential, GetTorrentListArg, Hashes, RatioLimit, SeedingTimeLimit,
         SetTorrentSharedLimitArg,
     },
-    Qbit,
 };
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
 use serde::Deserialize;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -25,28 +25,4 @@
     home-assistant-custom-themes = import ../pkgs/home-assistant-custom-themes { pkgs = final; };
     nodePackages = (prev.nodePackages or { }) // import ../pkgs/nodePackages { pkgs = final; };
   };
-
-  modifications = final: prev:
-    let
-      pkgsUnstable = import inputs.nixpkgs-unstable { inherit (final) system; };
-    in
-    {
-      # >= 2.26.0 is required for buildbot-nix
-      # TODO: remove during upgrade to 25.05
-      inherit (pkgsUnstable) nix-eval-jobs;
-
-      # >= 0.7.24 fixes service token expiry
-      # reference: https://github.com/al-one/hass-xiaomi-miot/issues/1956
-      # TODO: remove during upgrade to 25.05
-      home-assistant-custom-components = (prev.home-assistant-custom-components or { }) // {
-        xiaomi_miot = prev.home-assistant-custom-components.xiaomi_miot.overrideAttrs (prevAttrs: rec {
-          version = "0.7.24";
-          name = "python3.12-${prevAttrs.owner}-${prevAttrs.domain}-${version}";
-          src = prevAttrs.src.override {
-            rev = "v${version}";
-            hash = "sha256-DI2e3JBOyBUIUtEYS9ygR3B/XvpB5h6RrBdnNJiwyfY=";
-          };
-        });
-      };
-    };
 }


### PR DESCRIPTION
flake.nix:
- update nixpkgs to `nixos-25.05` branch
- remove `nixpkgs-unstable` (no longer used)
- update `home-manager` to `release-25.05` branch
- update `lanzaboote` v0.3.0 -> v0.4.2
- update `sylix` to `release-25.05` branch
- update `disko` v1.7.0 -> v1.12.0
- update `spicetify-nix` to main branch

overlays:
- removed backports

upstream changes that required the following changes:
- nixpkgs changed how nerdfonts fonts are packaged -> no longer need to override

other changes:
- run treeformat; rustfmt changed files

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/e55f9a8678adc02024a4877c2a403e3f6daf24fe?narHash=sha256-tqoAO8oT6zEUDXte98cvA1saU9%2B1dLJQe3pMKLXv8ps%3D' (2024-09-03)
  → 'github:nix-community/disko/ff442f5d1425feb86344c028298548024f21256d?narHash=sha256-eDoSOhxGEm2PykZFa/x9QG5eTH0MJdiJ9aR00VAofXE%3D' (2025-05-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d5f1f641b289553927b3801580598d200a501863?narHash=sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz%2BAFQF7n9NmNc%3D' (2025-05-19)
  → 'github:nix-community/home-manager/d0bbd221482c2713cccb80220f3c9d16a6e20a33?narHash=sha256-Qb84nbYFFk0DzFeqVoHltS2RodAYY5/HZQKE8WnBDsc%3D' (2025-05-18)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/64b903ca87d18cef2752c19c098af275c6e51d63?narHash=sha256-Fb5TeRTdvUlo/5Yi2d%2BFC8a6KoRLk2h1VE0/peMhWPs%3D' (2023-04-29)
  → 'github:nix-community/lanzaboote/a65905a09e2c43ff63be8c0e86a93712361f871e?narHash=sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU%3D' (2025-01-23)
• Updated input 'lanzaboote/crane/flake-compat':
    follows 'lanzaboote/flake-compat'
  → 'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Updated input 'lanzaboote/crane/flake-utils':
    follows 'lanzaboote/flake-utils'
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'lanzaboote/crane/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Updated input 'lanzaboote/crane/nixpkgs':
    follows 'lanzaboote/nixpkgs'
  → 'github:NixOS/nixpkgs/fe51d34885f7b5e3e7b59572796e1bcb427eccb1?narHash=sha256-qmmFCrfBwSHoWw7cVK4Aj%2Bfns%2Bc54EBP8cGqp/yK410%3D' (2025-05-22)
• Updated input 'lanzaboote/crane/rust-overlay':
    follows 'lanzaboote/rust-overlay'
  → 'github:oxalica/rust-overlay/476b2ba7dc99ddbf70b1f45357dbbdbdbdfb4422?narHash=sha256-GZcjWLQtDifSYMd1ueLDmuVTcQQdD5mONIBTqABooOk%3D' (2025-05-25)
• Added input 'lanzaboote/crane/rust-overlay/nixpkgs':
    follows 'lanzaboote/crane/nixpkgs'
• Removed input 'lanzaboote/flake-utils'
• Removed input 'lanzaboote/flake-utils/systems'
• Updated input 'lanzaboote/pre-commit-hooks-nix/flake-utils':
    follows 'lanzaboote/flake-utils'
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'lanzaboote/pre-commit-hooks-nix/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Updated input 'lanzaboote/rust-overlay/flake-utils':
    follows 'lanzaboote/flake-utils'
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'lanzaboote/rust-overlay/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Updated input 'nixvirt':
    'https://api.flakehub.com/f/pinned/AshleyYakeley/NixVirt/0.5.0/018eb55e-7beb-75c5-919f-5b5b26136e06/source.tar.gz?narHash=sha256-QoONoZPBpNTw5cia05QSvDlaxXo3moKAJQOw7c5hMXA%3D' (2024-04-06)
  → 'github:AshleyYakeley/NixVirt/5dfe108fd859b122f9a96981cb6bc12297653d6c?narHash=sha256-DNBZmuk1YRM2PmwbHzVdXumRjCUzQkMarg4iI/37rOQ%3D' (2025-05-25)
• Removed input 'nixvirt/nixpkgs-ovmf'
• Updated input 'spicetify':
    'github:Gerg-L/spicetify-nix/543f12dd14c62ddee79ab79fbfd8726f312b89ff?narHash=sha256-e3x1mhpPpYgyyin9j/VbrBpOT5PFpEfx2hkxVZuJZhg%3D' (2025-04-02)
  → 'github:Gerg-L/spicetify-nix/f0595e3b59260457042450749eaec00a5a47db35?narHash=sha256-9IaAQkgyF4PFtVyui8vF6oJah0iVcO9DaOefjdTMthE%3D' (2025-05-25)
• Updated input 'stylix':
    'github:danth/stylix/66f554e4e32d804bcf2c007a7b7efef04a3773b0?narHash=sha256-DYdmj22ZvkN5x9/VtdV5Wnze%2BUaPuboYraCPnOWn6u4%3D' (2025-05-20)
  → 'github:nix-community/stylix/df93f602dd8c84e7bd067654cc2f6422d5868496?narHash=sha256-qHewVAhQ2kaZLHcO9lDzMeAGDFmbDd36kls7bi7HgMQ%3D' (2025-05-23)
• Added input 'stylix/flake-parts':
    'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
• Added input 'stylix/flake-parts/nixpkgs-lib':
    follows 'stylix/nixpkgs'
• Removed input 'stylix/flake-utils'
• Removed input 'stylix/flake-utils/systems'
• Updated input 'stylix/gnome-shell':
    'github:GNOME/gnome-shell/dadd58f630eeea41d645ee225a63f719390829dc?narHash=sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg%3D' (2024-11-23)
  → 'github:GNOME/gnome-shell/52c517c8f6c199a1d6f5118fae500ef69ea845ae?narHash=sha256-0RJ4mJzf%2BklKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew%3D' (2025-04-13)
• Added input 'stylix/nur':
    'github:nix-community/NUR/621b7cd2462057ad0cf365b28e99ea95a3916bc4?narHash=sha256-z5aLC0QdFhYKeCmXNoSkOIc7/xJHrUltY0p0MzO1bO0%3D' (2025-05-25)
• Added input 'stylix/nur/flake-parts':
    follows 'stylix/flake-parts'
• Added input 'stylix/nur/nixpkgs':
    follows 'stylix/nixpkgs'
• Added input 'stylix/nur/treefmt-nix':
    'github:numtide/treefmt-nix/49717b5af6f80172275d47a418c9719a31a78b53?narHash=sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM%3D' (2024-12-03)
• Added input 'stylix/nur/treefmt-nix/nixpkgs':
    follows 'stylix/nur/nixpkgs'
• Updated input 'stylix/tinted-kitty':
    'github:tinted-theming/tinted-kitty/eb39e141db14baef052893285df9f266df041ff8?narHash=sha256-2xF3sH7UIwegn%2B2gKzMpFi3pk5DlIlM18%2Bvj17Uf82U%3D' (2024-05-23)
  → 'github:tinted-theming/tinted-kitty/de6f888497f2c6b2279361bfc790f164bfd0f3fa?narHash=sha256-4KtB%2BFiUzIeK/4aHCKce3V9HwRvYaxX%2BF1edUrfgzb8%3D' (2025-01-01)
• Added input 'stylix/tinted-schemes':
    'github:tinted-theming/schemes/87d652edd26f5c0c99deda5ae13dfb8ece2ffe31?narHash=sha256-7n0XiZiEHl2zRhDwZd/g%2Bp38xwEoWtT0/aESwTMXWG4%3D' (2025-05-25)
• Added input 'stylix/tinted-zed':
    'github:tinted-theming/base16-zed/122c9e5c0e6f27211361a04fae92df97940eccf9?narHash=sha256-8P1b6mJWyYcu36WRlSVbuj575QWIFZALZMTg5ID/sM4%3D' (2024-09-08)
